### PR TITLE
Updating the branch trigger to master branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,11 +3,11 @@ name: "CodeQL Scan"
 on:
   push:
     branches:
-      - main
+      - master
       - "release/**"
   pull_request:
     branches:
-      - main
+      - master
       - "release/**"
 
 permissions: # added using https://github.com/step-security/secure-workflows


### PR DESCRIPTION
main branch got renamed to master. Hence updating the CodeQL trigger to master branch.