### PR TITLE
[tracing] POC for a simple attribute based sampler

### DIFF
--- a/pkg/tracing/plugin/otlp.go
+++ b/pkg/tracing/plugin/otlp.go
@@ -38,6 +38,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
 
 const exporterPlugin = "otlp"
@@ -193,6 +194,11 @@ func newTracer(ctx context.Context, procs []trace.SpanProcessor) (io.Closer, err
 	for _, proc := range procs {
 		opts = append(opts, trace.WithSpanProcessor(proc))
 	}
+
+	attributes := map[string][]string{
+		string(semconv.RPCMethodKey): {"PullImage", "Create"},
+	}
+	opts = append(opts, trace.WithSampler(trace.ParentBased(AttributeBased(attributes))))
 	provider := trace.NewTracerProvider(opts...)
 	otel.SetTracerProvider(provider)
 

--- a/pkg/tracing/plugin/sampler.go
+++ b/pkg/tracing/plugin/sampler.go
@@ -1,0 +1,46 @@
+package plugin
+
+import (
+	"fmt"
+	"slices"
+
+	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type attributeSampler struct {
+	selectedAttrs map[string][]string
+}
+
+// AttributeBased returns a Sampler that samples every trace matching a set of attributes.
+// It only need to find one matching key-value pairs present in the attributes of the span.
+func AttributeBased(selectedAttrs map[string][]string) attributeSampler {
+	return attributeSampler{
+		selectedAttrs: selectedAttrs,
+	}
+}
+
+func (ss attributeSampler) ShouldSample(parameters sdkTrace.SamplingParameters) sdkTrace.SamplingResult {
+	psc := trace.SpanContextFromContext(parameters.ParentContext)
+	println(parameters.Name)
+	for _, attr := range parameters.Attributes {
+		println(attr.Key, attr.Value.Emit())
+		if selectedValues, ok := ss.selectedAttrs[string(attr.Key)]; ok {
+			if slices.Contains(selectedValues, attr.Value.Emit()) {
+				println("Sampled")
+				return sdkTrace.SamplingResult{
+					Decision:   sdkTrace.RecordAndSample,
+					Tracestate: psc.TraceState(),
+				}
+			}
+		}
+	}
+	return sdkTrace.SamplingResult{
+		Decision:   sdkTrace.Drop,
+		Tracestate: psc.TraceState(),
+	}
+}
+
+func (ss attributeSampler) Description() string {
+	return fmt.Sprintf("AttributeBased:{%v}", ss.selectedAttrs)
+}


### PR DESCRIPTION
Can be used to filter out traces based on any attribute present on the span
However it is quite complex to use (shall we OR or AND the different args) and not very efficient in terms of computation (while traces should be sampled quickly. So I will rather expand on julien's nameBased tracer https://github.com/DataDog/containerd/compare/release-1.7.12-dd-imgverify-0...DataDog:containerd:jb/v1.7.12-otel