### PR TITLE
Port name sampler to containerd v2 (#7)

### DIFF
--- a/pkg/tracing/plugin/sampler.go
+++ b/pkg/tracing/plugin/sampler.go
@@ -1,0 +1,51 @@
+package plugin
+
+import (
+	"fmt"
+
+	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	samplerNameBased       = "namebased"
+	samplerParentBasedName = "parentbased_name"
+)
+
+type NameSampler struct {
+	// allow is a set of names that should be sampled.
+	// Uses a map of empty structs for O(1) lookups and no memory overhead.
+	allow map[string]struct{}
+}
+
+// NameBased returns a Sampler that samples every span having a certain name.
+// It should be used in conjunction with the ParentBased sampler so that the child spans are also sampled.
+func NameBased(allowedNames []string) NameSampler {
+	allowedNamesMap := make(map[string]struct{}, len(allowedNames))
+	for _, name := range allowedNames {
+		allowedNamesMap[name] = struct{}{}
+	}
+	return NameSampler{
+		allow: allowedNamesMap,
+	}
+}
+
+func (ns NameSampler) ShouldSample(parameters sdkTrace.SamplingParameters) sdkTrace.SamplingResult {
+	psc := trace.SpanContextFromContext(parameters.ParentContext)
+
+	if _, ok := ns.allow[parameters.Name]; ok {
+		return sdkTrace.SamplingResult{
+			Decision:   sdkTrace.RecordAndSample,
+			Tracestate: psc.TraceState(),
+		}
+	}
+
+	return sdkTrace.SamplingResult{
+		Decision:   sdkTrace.Drop,
+		Tracestate: psc.TraceState(),
+	}
+}
+
+func (ns NameSampler) Description() string {
+	return fmt.Sprintf("NameBased:{%v}", ns.allow)
+}


### PR DESCRIPTION
* [tracing] Create NameSampler

Simple sampler that samples every span having a certain name. It's best used in conjunction with the ParentBased sampler so that the child spans are also sampled.

* [tracing] Configure otlp plugin to use NameSampler

Allow the plugin to use the custom NameSampler if specified in the usual env vars used to specify the sampler `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG`. This sampler will allow to avoid emitting a lot of the noisy traces to only keep a subset of meaningful traces.