### PR TITLE
Stable sort for RuntimeHandlers

### DIFF
--- a/internal/cri/server/status.go
+++ b/internal/cri/server/status.go
@@ -23,6 +23,7 @@ import (
 	"maps"
 	goruntime "runtime"
 	"slices"
+	"sort"
 
 	"github.com/containerd/containerd/api/services/introspection/v1"
 	"github.com/containerd/log"
@@ -59,9 +60,15 @@ func (c *criService) Status(ctx context.Context, r *runtime.StatusRequest) (*run
 			runtimeCondition,
 			networkCondition,
 		}},
-		RuntimeHandlers: slices.Collect(maps.Values(c.runtimeHandlers)),
-		Features:        c.runtimeFeatures,
+		Features: c.runtimeFeatures,
 	}
+
+	// Get runtime handlers in a stable order
+	resp.RuntimeHandlers = slices.Collect(maps.Values(c.runtimeHandlers))
+	sort.SliceStable(resp.RuntimeHandlers, func(i, j int) bool {
+		return resp.RuntimeHandlers[i].Name < resp.RuntimeHandlers[j].Name
+	})
+
 	if r.Verbose {
 		configByt, err := json.Marshal(c.config)
 		if err != nil {


### PR DESCRIPTION
The runtimeHandlers list in the response to `crictl info` has unstable ordering
since commit https://github.com/DataDog/containerd/commit/97eb1cd46f49dc3cce86eebada315cfabcafe575 that uses a map instead of a list.

This causes the kubelet to update node status subresources every few seconds
leading to excessive API server load.

This change enforces stable ordering based on the runtime handler name.