### PR TITLE
[v2.1-dd] Cherry-picks 

### DIFF
--- a/pkg/tracing/plugin/sampler.go
+++ b/pkg/tracing/plugin/sampler.go
@@ -1,0 +1,51 @@
+package plugin
+
+import (
+	"fmt"
+
+	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	samplerNameBased       = "namebased"
+	samplerParentBasedName = "parentbased_name"
+)
+
+type NameSampler struct {
+	// allow is a set of names that should be sampled.
+	// Uses a map of empty structs for O(1) lookups and no memory overhead.
+	allow map[string]struct{}
+}
+
+// NameBased returns a Sampler that samples every span having a certain name.
+// It should be used in conjunction with the ParentBased sampler so that the child spans are also sampled.
+func NameBased(allowedNames []string) NameSampler {
+	allowedNamesMap := make(map[string]struct{}, len(allowedNames))
+	for _, name := range allowedNames {
+		allowedNamesMap[name] = struct{}{}
+	}
+	return NameSampler{
+		allow: allowedNamesMap,
+	}
+}
+
+func (ns NameSampler) ShouldSample(parameters sdkTrace.SamplingParameters) sdkTrace.SamplingResult {
+	psc := trace.SpanContextFromContext(parameters.ParentContext)
+
+	if _, ok := ns.allow[parameters.Name]; ok {
+		return sdkTrace.SamplingResult{
+			Decision:   sdkTrace.RecordAndSample,
+			Tracestate: psc.TraceState(),
+		}
+	}
+
+	return sdkTrace.SamplingResult{
+		Decision:   sdkTrace.Drop,
+		Tracestate: psc.TraceState(),
+	}
+}
+
+func (ns NameSampler) Description() string {
+	return fmt.Sprintf("NameBased:{%v}", ns.allow)
+}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -18,6 +18,7 @@ package tracing
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -129,4 +131,12 @@ func Attribute(k string, v any) attribute.KeyValue {
 // specification for a span.
 func HTTPStatusCodeAttributes(code int) []attribute.KeyValue {
 	return []attribute.KeyValue{semconv.HTTPStatusCodeKey.Int(code)}
+}
+
+// GetPropagatorsTraceContext returns the current propagators trace context as a JSON string
+func GetPropagatorsTraceContext(ctx context.Context) ([]byte, error) {
+	propagator := propagation.TraceContext{}
+	carrier := propagation.MapCarrier{}
+	propagator.Inject(ctx, carrier)
+	return json.Marshal(carrier)
 }


### PR DESCRIPTION
In an attempt to simplify the maintenance of our fork, I've created a new branch `v2.1-dd` to act as a long lived version of `release/2.1` + our changes. Currently, it was created off of upstreams `v2.1.4` tag. 

As such, this PR cherry-picks the following commits that are not present in the upstream v2.1.4 release:
* https://github.com/DataDog/containerd/pull/7 
* https://github.com/DataDog/containerd/pull/10 


Notably, https://github.com/containerd/containerd/pull/12036 was cherry-picked upstream to 2.1 via https://github.com/containerd/containerd/pull/12054 and is included in the 2.1.4 release.

Once merged, I'll tag and push v2.1.4-dd.0`. Future releases can be incorporated by simply:
```
# Assumes you have a remote `upstream` for containerd/containerd and `fork` for Datadog/containerd

git fetch --all 
git checkout v2.1-dd
git merge v2.1.X 
git tag v2.1.X-dd.X
git push --tags fork v2.1-dd
```

