### PR TITLE
[2.1] Cherry-pick: [github-action] release - Empty allowedSignersFile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Check signature
         run: |
+          touch ${{ runner.temp }}/empty-allowedSignersFile
+          git config --global gpg.ssh.allowedSignersFile ${{ runner.temp }}/empty-allowedSignersFile
           releasever=${{ github.ref }}
           releasever="${releasever#refs/tags/}"
           TAGCHECK=$(git tag -v ${releasever} 2>&1 >/dev/null) ||


### PR DESCRIPTION
Backport of https://github.com/containerd/containerd/pull/12304 