### PR TITLE
[v2.2-dd] Cherry picks

### DIFF
--- a/pkg/tracing/plugin/sampler.go
+++ b/pkg/tracing/plugin/sampler.go
@@ -1,0 +1,51 @@
+package plugin
+
+import (
+	"fmt"
+
+	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	samplerNameBased       = "namebased"
+	samplerParentBasedName = "parentbased_name"
+)
+
+type NameSampler struct {
+	// allow is a set of names that should be sampled.
+	// Uses a map of empty structs for O(1) lookups and no memory overhead.
+	allow map[string]struct{}
+}
+
+// NameBased returns a Sampler that samples every span having a certain name.
+// It should be used in conjunction with the ParentBased sampler so that the child spans are also sampled.
+func NameBased(allowedNames []string) NameSampler {
+	allowedNamesMap := make(map[string]struct{}, len(allowedNames))
+	for _, name := range allowedNames {
+		allowedNamesMap[name] = struct{}{}
+	}
+	return NameSampler{
+		allow: allowedNamesMap,
+	}
+}
+
+func (ns NameSampler) ShouldSample(parameters sdkTrace.SamplingParameters) sdkTrace.SamplingResult {
+	psc := trace.SpanContextFromContext(parameters.ParentContext)
+
+	if _, ok := ns.allow[parameters.Name]; ok {
+		return sdkTrace.SamplingResult{
+			Decision:   sdkTrace.RecordAndSample,
+			Tracestate: psc.TraceState(),
+		}
+	}
+
+	return sdkTrace.SamplingResult{
+		Decision:   sdkTrace.Drop,
+		Tracestate: psc.TraceState(),
+	}
+}
+
+func (ns NameSampler) Description() string {
+	return fmt.Sprintf("NameBased:{%v}", ns.allow)
+}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -18,6 +18,7 @@ package tracing
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -131,4 +133,12 @@ func HTTPStatusCodeAttributes(code int) []attribute.KeyValue {
 		attribute.Int("http.response.status_code", code),
 		attribute.Int("http.status_code", code), // Deprecated: SemConv <= v1.21
 	}
+}
+
+// GetPropagatorsTraceContext returns the current propagators trace context as a JSON string
+func GetPropagatorsTraceContext(ctx context.Context) ([]byte, error) {
+	propagator := propagation.TraceContext{}
+	carrier := propagation.MapCarrier{}
+	propagator.Inject(ctx, carrier)
+	return json.Marshal(carrier)
 }


### PR DESCRIPTION
Similar to https://github.com/DataDog/containerd/pull/17 

This PR cherry-picks to the 2.2 release the following PR's that are not found upstream: 
* https://github.com/DataDog/containerd/pull/7
* https://github.com/DataDog/containerd/pull/10

Looking at https://github.com/DataDog/containerd/compare/release/2.1...v2.1-dd the only other change we had was https://github.com/DataDog/containerd/pull/18 but that's been merged upstream and is included in 2.2 via https://github.com/containerd/containerd/pull/12304 