### PR TITLE
cri: sanitize URLs in ErrUnexpectedStatus errors

### DIFF
--- a/internal/cri/util/sanitize.go
+++ b/internal/cri/util/sanitize.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"net/url"
 	"strings"
+
+	remoteerrors "github.com/containerd/containerd/v2/core/remotes/errors"
 )
 
 // SanitizeError sanitizes an error by redacting sensitive information in URLs.
@@ -30,24 +32,31 @@ func SanitizeError(err error) error {
 		return nil
 	}
 
-	// Check if the error is or contains a *url.Error
+	// Determine the raw URL embedded in the error message, if any.
+	var rawURL string
 	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
-		// Parse and sanitize the URL
-		sanitizedURL := sanitizeURL(urlErr.URL)
-		if sanitizedURL != urlErr.URL {
-			// Wrap with sanitized url.Error
-			return &sanitizedError{
-				original:     err,
-				sanitizedURL: sanitizedURL,
-				urlError:     urlErr,
-			}
-		}
+	var statusErr remoteerrors.ErrUnexpectedStatus
+	switch {
+	case errors.As(err, &urlErr):
+		rawURL = urlErr.URL
+	case errors.As(err, &statusErr):
+		// ErrUnexpectedStatus embeds the raw request URL (including signed
+		// query params) in its message but is not a *url.Error.
+		rawURL = statusErr.RequestURL
+	default:
+		// No sanitization needed for non-URL errors
 		return err
 	}
 
-	// No sanitization needed for non-URL errors
-	return err
+	sanitizedURL := sanitizeURL(rawURL)
+	if sanitizedURL == rawURL {
+		return err
+	}
+	return &sanitizedError{
+		original:     err,
+		originalURL:  rawURL,
+		sanitizedURL: sanitizedURL,
+	}
 }
 
 // sanitizeURL properly parses a URL and redacts all query parameters.
@@ -74,17 +83,17 @@ func sanitizeURL(rawURL string) string {
 	return parsed.String()
 }
 
-// sanitizedError wraps an error containing a *url.Error with a sanitized URL.
+// sanitizedError wraps an error whose message embeds a URL with a sanitized URL.
 type sanitizedError struct {
 	original     error
+	originalURL  string
 	sanitizedURL string
-	urlError     *url.Error
 }
 
 // Error returns the error message with the sanitized URL.
 func (e *sanitizedError) Error() string {
 	// Replace all occurrences of the original URL with the sanitized version
-	return strings.ReplaceAll(e.original.Error(), e.urlError.URL, e.sanitizedURL)
+	return strings.ReplaceAll(e.original.Error(), e.originalURL, e.sanitizedURL)
 }
 
 // Unwrap returns the original error for error chain traversal.

--- a/internal/cri/util/sanitize.go
+++ b/internal/cri/util/sanitize.go
@@ -25,8 +25,8 @@ import (
 )
 
 // SanitizeError sanitizes an error by redacting sensitive information in URLs.
-// If the error contains a *url.Error, it parses and sanitizes the URL.
-// Otherwise, it returns the error unchanged.
+// If the error contains a *url.Error or an ErrUnexpectedStatus, it parses and
+// sanitizes the embedded URL. Otherwise, it returns the error unchanged.
 func SanitizeError(err error) error {
 	if err == nil {
 		return nil

--- a/internal/cri/util/sanitize_test.go
+++ b/internal/cri/util/sanitize_test.go
@@ -43,7 +43,7 @@ func TestSanitizeError_SimpleURLError(t *testing.T) {
 	sanitizedErr, ok := sanitized.(*sanitizedError)
 	require.True(t, ok, "Should return *sanitizedError type")
 	assert.Equal(t, urlErr, sanitizedErr.original)
-	assert.Equal(t, urlErr, sanitizedErr.urlError)
+	assert.Equal(t, originalURL, sanitizedErr.originalURL)
 	assert.Equal(t, "https://storage.blob.core.windows.net/container/blob?sig=%5BREDACTED%5D&sv=%5BREDACTED%5D", sanitizedErr.sanitizedURL)
 
 	// Test Error() method - verifies ReplaceAll functionality

--- a/internal/cri/util/sanitize_test.go
+++ b/internal/cri/util/sanitize_test.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"testing"
 
+	remoteerrors "github.com/containerd/containerd/v2/core/remotes/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -78,6 +79,80 @@ func TestSanitizeError_WrappedError(t *testing.T) {
 	// Verify url.Error properties are preserved
 	assert.Equal(t, "Get", targetURLErr.Op)
 	assert.Contains(t, targetURLErr.Err.Error(), "timeout")
+}
+
+func TestSanitizeError_UnexpectedStatusError(t *testing.T) {
+	// Registry non-2xx responses (e.g. 503 from an S3-backed blob redirect)
+	// return an ErrUnexpectedStatus, whose message embeds the raw signed URL
+	// but which is not a *url.Error.
+	originalURL := "https://prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com/blob?X-Amz-Security-Token=SECRET_TOKEN&X-Amz-Signature=SECRET_SIG&rid=abc123"
+	statusErr := remoteerrors.ErrUnexpectedStatus{
+		Status:        "503 Slow Down",
+		StatusCode:    503,
+		RequestURL:    originalURL,
+		RequestMethod: "GET",
+	}
+
+	sanitized := SanitizeError(statusErr)
+	require.NotNil(t, sanitized)
+
+	// Check it's a sanitizedError with correct properties
+	sanitizedErr, ok := sanitized.(*sanitizedError)
+	require.True(t, ok, "Should return *sanitizedError type")
+	assert.Equal(t, originalURL, sanitizedErr.originalURL)
+
+	// Every query param value must be redacted.
+	msg := sanitized.Error()
+	assert.NotContains(t, msg, "SECRET_TOKEN", "Security token should be sanitized")
+	assert.NotContains(t, msg, "SECRET_SIG", "Signature should be sanitized")
+	assert.NotContains(t, msg, "abc123", "All query params should be sanitized")
+	assert.Contains(t, msg, "%5BREDACTED%5D", "Should contain sanitized marker")
+	assert.Contains(t, msg, "unexpected status from GET request to", "Status message should be preserved")
+	assert.Contains(t, msg, "503 Slow Down", "Status text should be preserved")
+}
+
+func TestSanitizeError_WrappedUnexpectedStatusError(t *testing.T) {
+	// Mirrors the real log path: the fetch error is wrapped by httpReadSeeker
+	// and again by the image-pull layer. errors.As must find the value-type
+	// ErrUnexpectedStatus through the wrappers.
+	originalURL := "https://prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com/blob?X-Amz-Signature=SECRET_SIG&X-Amz-Credential=SECRET_CRED"
+	statusErr := remoteerrors.ErrUnexpectedStatus{
+		Status:        "503 Slow Down",
+		StatusCode:    503,
+		RequestURL:    originalURL,
+		RequestMethod: "GET",
+	}
+	wrappedErr := fmt.Errorf("failed to copy: httpReadSeeker: failed open: %w", statusErr)
+
+	sanitized := SanitizeError(wrappedErr)
+
+	msg := sanitized.Error()
+	assert.NotContains(t, msg, "SECRET_SIG", "Signature should be sanitized")
+	assert.NotContains(t, msg, "SECRET_CRED", "Credential should be sanitized")
+	assert.Contains(t, msg, "%5BREDACTED%5D", "Should contain sanitized marker")
+	assert.Contains(t, msg, "httpReadSeeker: failed open", "Wrapper message should be preserved")
+
+	// Should still be able to unwrap to the original ErrUnexpectedStatus.
+	var targetStatusErr remoteerrors.ErrUnexpectedStatus
+	assert.True(t, errors.As(sanitized, &targetStatusErr),
+		"Should be able to find ErrUnexpectedStatus in sanitized error chain")
+	assert.Equal(t, 503, targetStatusErr.StatusCode)
+}
+
+func TestSanitizeError_UnexpectedStatusNoQueryParams(t *testing.T) {
+	// A registry error whose URL has no query params has nothing to redact and
+	// must pass through unchanged.
+	statusErr := remoteerrors.ErrUnexpectedStatus{
+		Status:        "500 Internal Server Error",
+		StatusCode:    500,
+		RequestURL:    "https://registry.example.com/v2/image/blobs/sha256:abc",
+		RequestMethod: "GET",
+	}
+
+	sanitized := SanitizeError(statusErr)
+
+	assert.Equal(t, statusErr, sanitized,
+		"Registry errors without query params should pass through unchanged")
 }
 
 func TestSanitizeError_NonURLError(t *testing.T) {


### PR DESCRIPTION
SanitizeError only redacted URLs carried by *url.Error, which covers transport-level failures (connection reset, DNS) but not registry non-200 responses. Those return ErrUnexpectedStatus, whose Error() embeds the raw request URL - including signed query params such as X-Amz-Signature and X-Amz-Security-Token - and is not a *url.Error, so it passed through unredacted and leaked tokens into logs (e.g. on 503 Slow Down from S3-backed registries).

Also match ErrUnexpectedStatus and redact its RequestURL. The sanitizedError wrapper now stores the raw URL string rather than a *url.Error, since both source types share the same redaction path.